### PR TITLE
resolve potential conflicts with other npm compdefs

### DIFF
--- a/npm-run.plugin.zsh
+++ b/npm-run.plugin.zsh
@@ -1,11 +1,11 @@
 #
 # npm-run.plugin.zsh
-# 
+#
 # Autocompletion for `npm run scripts`
 #
 # Copyright(c) 2015 André König <andre.koenig@posteo.de>
 # MIT Licensed
-# 
+#
 
 function _scripts () {
      compls=$([[ -s $PWD/package.json ]] || return 0 && cat package.json | tr -d " \t\n\r" | grep -oP 'scripts\"\:\{(.*?)\}' | sed -e "s/scripts\"\://g" | sed -e "s/{//g" | grep -oP '\"(.*?):\"' | sed -e 's/\"//g' | sed -e 's/\://g' | sed -e 's/\,//g' | sort)
@@ -14,4 +14,4 @@ function _scripts () {
     compadd -- $completions
 }
 
-compdef _scripts npm run
+compdef _scripts "npm run"


### PR DESCRIPTION
I noticed that having the compdef named as `npm run` will break any other plugins that use the npm keyword to trigger tab completion. 

It was resolved simply by adding quotes around the compdef name ` "npm run" ` instead of `npm run`. 
